### PR TITLE
Fix slow XRd boot

### DIFF
--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -116,12 +116,6 @@ func (n *Node) Create(ctx context.Context) error {
 		tty = true
 		stdin = true
 	}
-	if pb.Model == ModelXRD {
-		stdin := true
-		tty := true
-	} else {
-		stdin := false
-		tty := false
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: n.Name(),

--- a/topo/node/cisco/cisco.go
+++ b/topo/node/cisco/cisco.go
@@ -139,7 +139,7 @@ func (n *Node) Create(ctx context.Context) error {
 				Image:           pb.Config.Image,
 				Command:         pb.Config.Command,
 				Args:            pb.Config.Args,
-				Tty:             tty,
+				TTY:             tty,
 				Stdin:           stdin,
 				Env:             node.ToEnvVar(pb.Config.Env),
 				Resources:       node.ToResourceRequirements(pb.Constraints),


### PR DESCRIPTION
XRd boot is slow as the Kubernetes manifest does not have

```
tty: true
stdin: true
```

set for the container. XRd requires these as it attempts to create a tty on boot.

Without these set, the XRd boot is slow at over 2 minutes. With these set the boot is a few seconds.